### PR TITLE
Bump spring.version from 5.1.2.RELEASE to 5.2.3.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<jdk.version>1.8</jdk.version>
-		<spring.version>5.1.2.RELEASE</spring.version>
+		<spring.version>5.2.3.RELEASE</spring.version>
 		<junit.version>4.11</junit.version>
 		<log4j.version>1.2.17</log4j.version>
 		<sonar.host.url>http://15.206.69.51:9000/</sonar.host.url>


### PR DESCRIPTION
Bumps `spring.version` from 5.1.2.RELEASE to 5.2.3.RELEASE.

Updates `spring-core` from 5.1.2.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.1.2.RELEASE...v5.2.3.RELEASE)

Updates `spring-web` from 5.1.2.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.1.2.RELEASE...v5.2.3.RELEASE)

Updates `spring-webmvc` from 5.1.2.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.1.2.RELEASE...v5.2.3.RELEASE)

Updates `spring-context` from 5.1.2.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.1.2.RELEASE...v5.2.3.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>